### PR TITLE
set BufferedImage type of altered image to type of original image

### DIFF
--- a/testProject-8.0/javasource/imagecrop/implementation/ImageUtil.java
+++ b/testProject-8.0/javasource/imagecrop/implementation/ImageUtil.java
@@ -31,7 +31,7 @@ public class ImageUtil {
 		try ( InputStream is = Core.getImage(context, colorImageObj, false) )
 		{
 			BufferedImage originalImage = ImageIO.read(is);
-			BufferedImage alteredImage = new BufferedImage(originalImage.getWidth(), originalImage.getHeight(), BufferedImage.TYPE_INT_RGB);
+			BufferedImage alteredImage = new BufferedImage(originalImage.getWidth(), originalImage.getHeight(), originalImage.getType());
 			
 	        ColorConvertOp op = new ColorConvertOp(ColorSpace.getInstance(ColorSpace.CS_GRAY), null);
 	        op.filter(originalImage, alteredImage);
@@ -49,7 +49,7 @@ public class ImageUtil {
 		try ( InputStream is = Core.getImage(context, imageObj, false) ) 
 		{
 			BufferedImage originalImage = ImageIO.read(is);
-			BufferedImage alteredImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+			BufferedImage alteredImage = new BufferedImage(width, height, originalImage.getType());
 			
 			if (crop) {
 				alteredImage.getGraphics().drawImage(originalImage, 0, 0, width, height, x1, y1, x2, y2, null);


### PR DESCRIPTION
Because the BufferedImage type was hardcoded to RGB, any transparency in a .png for example was lost.

By setting the BufferedImage type of the altered image equal to the BufferedImage type of original image, transparency is kept in the alteredImage.