### PR TITLE
Allow PNGs to keep their alpha channel

### DIFF
--- a/Cropper/package.json
+++ b/Cropper/package.json
@@ -1,53 +1,53 @@
 {
-    "name": "cropper",
-    "version": "4.0.0",
-    "description": "Image Cropping Widget",
-    "main": "index.js",
-    "scripts": {
-        "dev": "cross-env MODE=development webpack --config conf/webpack.config.js",
-        "build": "cross-env MODE=production webpack --config conf/webpack.config.js"
-    },
-    "keywords": [
-        "Mendix",
-        "widget",
-        "Dojo",
-        "Javascript",
-        "ES6",
-        "JQUERY"
-    ],
-    "author": {
-        "name": "Osama Najjar",
-        "email": "osama.najjar@mendix.com"
-    },
-    "license": "MIT",
-    "devDependencies": {
-        "@babel/core": "^7.2.2",
-        "@babel/preset-env": "^7.2.3",
-        "autoprefixer": "^9.4.3",
-        "babel": "^6.23.0",
-        "babel-loader": "^8.0.4",
-        "babel-plugin-add-module-exports": "^1.0.0",
-        "concurrently": "^4.1.0",
-        "cross-env": "^5.2.0",
-        "css-loader": "^2.1.0",
-        "cssnano": "^4.1.8",
-        "file-loader": "^3.0.1",
-        "fs-extra": "^7.0.1",
-        "imports-loader": "^0.8.0",
-        "mini-css-extract-plugin": "^0.5.0",
-        "node-sass": "^4.13.0",
-        "postcss-clean": "^1.1.0",
-        "postcss-loader": "^3.0.0",
-        "sass-loader": "^7.2.0",
-        "style-loader": "^0.23.1",
-        "uglifyjs-webpack-plugin": "^2.1.1",
-        "webpack": "^4.28.2",
-        "webpack-archive-plugin": "^3.0.0",
-        "webpack-cli": "^3.1.2",
-        "xml-webpack-plugin": "0.0.2"
-    },
-    "dependencies": {
-        "jquery": "^3.3.1",
-        "jquery-jcrop": "^0.9.13"
-    }
+  "name": "cropper",
+  "version": "4.1.0",
+  "description": "Image Cropping Widget",
+  "main": "index.js",
+  "scripts": {
+    "dev": "cross-env MODE=development webpack --config conf/webpack.config.js",
+    "build": "cross-env MODE=production webpack --config conf/webpack.config.js"
+  },
+  "keywords": [
+    "Mendix",
+    "widget",
+    "Dojo",
+    "Javascript",
+    "ES6",
+    "JQUERY"
+  ],
+  "author": {
+    "name": "Osama Najjar",
+    "email": "osama.najjar@mendix.com"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@babel/core": "^7.2.2",
+    "@babel/preset-env": "^7.2.3",
+    "autoprefixer": "^9.4.3",
+    "babel": "^6.23.0",
+    "babel-loader": "^8.0.4",
+    "babel-plugin-add-module-exports": "^1.0.0",
+    "concurrently": "^4.1.0",
+    "cross-env": "^5.2.0",
+    "css-loader": "^2.1.0",
+    "cssnano": "^4.1.8",
+    "file-loader": "^3.0.1",
+    "fs-extra": "^7.0.1",
+    "imports-loader": "^0.8.0",
+    "mini-css-extract-plugin": "^0.5.0",
+    "node-sass": "^4.13.0",
+    "postcss-clean": "^1.1.0",
+    "postcss-loader": "^3.0.0",
+    "sass-loader": "^7.2.0",
+    "style-loader": "^0.23.1",
+    "uglifyjs-webpack-plugin": "^2.1.1",
+    "webpack": "^4.28.2",
+    "webpack-archive-plugin": "^3.0.0",
+    "webpack-cli": "^3.1.2",
+    "xml-webpack-plugin": "0.0.2"
+  },
+  "dependencies": {
+    "jquery": "^3.3.1",
+    "jquery-jcrop": "^0.9.13"
+  }
 }

--- a/src_module/javasource/imagecrop/implementation/ImageUtil.java
+++ b/src_module/javasource/imagecrop/implementation/ImageUtil.java
@@ -31,7 +31,7 @@ public class ImageUtil {
 		try ( InputStream is = Core.getImage(context, colorImageObj, false) )
 		{
 			BufferedImage originalImage = ImageIO.read(is);
-			BufferedImage alteredImage = new BufferedImage(originalImage.getWidth(), originalImage.getHeight(), BufferedImage.TYPE_INT_RGB);
+			BufferedImage alteredImage = new BufferedImage(originalImage.getWidth(), originalImage.getHeight(), originalImage.getType());
 			
 	        ColorConvertOp op = new ColorConvertOp(ColorSpace.getInstance(ColorSpace.CS_GRAY), null);
 	        op.filter(originalImage, alteredImage);
@@ -49,7 +49,7 @@ public class ImageUtil {
 		try ( InputStream is = Core.getImage(context, imageObj, false) ) 
 		{
 			BufferedImage originalImage = ImageIO.read(is);
-			BufferedImage alteredImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+			BufferedImage alteredImage = new BufferedImage(width, height, originalImage.getType());
 			
 			if (crop) {
 				alteredImage.getGraphics().drawImage(originalImage, 0, 0, width, height, x1, y1, x2, y2, null);

--- a/src_module/javasource/imagecrop/implementation/ImageUtil.java
+++ b/src_module/javasource/imagecrop/implementation/ImageUtil.java
@@ -31,7 +31,8 @@ public class ImageUtil {
 		try ( InputStream is = Core.getImage(context, colorImageObj, false) )
 		{
 			BufferedImage originalImage = ImageIO.read(is);
-			BufferedImage alteredImage = new BufferedImage(originalImage.getWidth(), originalImage.getHeight(), originalImage.getType());
+			Integer imageType = (originalImage.getColorModel().hasAlpha()) ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB;
+			BufferedImage alteredImage = new BufferedImage(originalImage.getWidth(), originalImage.getHeight(), imageType);
 			
 	        ColorConvertOp op = new ColorConvertOp(ColorSpace.getInstance(ColorSpace.CS_GRAY), null);
 	        op.filter(originalImage, alteredImage);
@@ -49,7 +50,8 @@ public class ImageUtil {
 		try ( InputStream is = Core.getImage(context, imageObj, false) ) 
 		{
 			BufferedImage originalImage = ImageIO.read(is);
-			BufferedImage alteredImage = new BufferedImage(width, height, originalImage.getType());
+			Integer imageType = (originalImage.getColorModel().hasAlpha()) ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB;
+			BufferedImage alteredImage = new BufferedImage(width, height, imageType);
 			
 			if (crop) {
 				alteredImage.getGraphics().drawImage(originalImage, 0, 0, width, height, x1, y1, x2, y2, null);

--- a/testProject-8.0/javasource/imagecrop/implementation/ImageUtil.java
+++ b/testProject-8.0/javasource/imagecrop/implementation/ImageUtil.java
@@ -31,7 +31,7 @@ public class ImageUtil {
 		try ( InputStream is = Core.getImage(context, colorImageObj, false) )
 		{
 			BufferedImage originalImage = ImageIO.read(is);
-			BufferedImage alteredImage = new BufferedImage(originalImage.getWidth(), originalImage.getHeight(), BufferedImage.TYPE_INT_RGB);
+			BufferedImage alteredImage = new BufferedImage(originalImage.getWidth(), originalImage.getHeight(), originalImage.getType());
 			
 	        ColorConvertOp op = new ColorConvertOp(ColorSpace.getInstance(ColorSpace.CS_GRAY), null);
 	        op.filter(originalImage, alteredImage);
@@ -49,7 +49,7 @@ public class ImageUtil {
 		try ( InputStream is = Core.getImage(context, imageObj, false) ) 
 		{
 			BufferedImage originalImage = ImageIO.read(is);
-			BufferedImage alteredImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+			BufferedImage alteredImage = new BufferedImage(width, height, originalImage.getType());
 			
 			if (crop) {
 				alteredImage.getGraphics().drawImage(originalImage, 0, 0, width, height, x1, y1, x2, y2, null);

--- a/testProject-8.0/javasource/imagecrop/implementation/ImageUtil.java
+++ b/testProject-8.0/javasource/imagecrop/implementation/ImageUtil.java
@@ -51,8 +51,8 @@ public class ImageUtil {
 		{
 			BufferedImage originalImage = ImageIO.read(is);
 			Integer imageType = (originalImage.getColorModel().hasAlpha()) ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB;
-			BufferedImage alteredImage = new BufferedImage(width, height, imageType;
-			
+			BufferedImage alteredImage = new BufferedImage(width, height, imageType);
+
 			if (crop) {
 				alteredImage.getGraphics().drawImage(originalImage, 0, 0, width, height, x1, y1, x2, y2, null);
 			} else 

--- a/testProject-8.0/javasource/imagecrop/implementation/ImageUtil.java
+++ b/testProject-8.0/javasource/imagecrop/implementation/ImageUtil.java
@@ -31,7 +31,8 @@ public class ImageUtil {
 		try ( InputStream is = Core.getImage(context, colorImageObj, false) )
 		{
 			BufferedImage originalImage = ImageIO.read(is);
-			BufferedImage alteredImage = new BufferedImage(originalImage.getWidth(), originalImage.getHeight(), originalImage.getType());
+			Integer imageType = (originalImage.getColorModel().hasAlpha()) ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB;
+			BufferedImage alteredImage = new BufferedImage(originalImage.getWidth(), originalImage.getHeight(), imageType);
 			
 	        ColorConvertOp op = new ColorConvertOp(ColorSpace.getInstance(ColorSpace.CS_GRAY), null);
 	        op.filter(originalImage, alteredImage);
@@ -49,7 +50,8 @@ public class ImageUtil {
 		try ( InputStream is = Core.getImage(context, imageObj, false) ) 
 		{
 			BufferedImage originalImage = ImageIO.read(is);
-			BufferedImage alteredImage = new BufferedImage(width, height, originalImage.getType());
+			Integer imageType = (originalImage.getColorModel().hasAlpha()) ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB;
+			BufferedImage alteredImage = new BufferedImage(width, height, imageType;
 			
 			if (crop) {
 				alteredImage.getGraphics().drawImage(originalImage, 0, 0, width, height, x1, y1, x2, y2, null);


### PR DESCRIPTION
Hi, we (Data Hub Catalog team) are working on a feature that allows customers to upload their custom logos.
We noticed that transparent images will have their background turn into black because the image gets a hardcoded RGB image type. This change will allow for images that have their transparency saved in an Alpha channel, keep their transparency by setting it to ARGB in those cases.

Kind regards,
Nam